### PR TITLE
refactor(convert): format converted mocks

### DIFF
--- a/src/core/convert.spec.ts
+++ b/src/core/convert.spec.ts
@@ -61,12 +61,12 @@ describe('Converter', () => {
             it('converts old mock.json', () =>
                 assert.calledWith(fsOutputJsonSyncFn, path.join(process.cwd(), 'destination', 'mock', 'old.mock.json'), {
                     name: 'old.mock', request: {method: 'GET', url: 'old/mock'}, responses: {'old-json-response': {}}
-                }));
+                }, {spaces: 2}));
 
             it('does not convert new mock.json', () =>
                 assert.calledWith(fsOutputJsonSyncFn, path.join(process.cwd(), 'destination', 'mock', 'new.mock.json'), {
                     name: 'new.mock', request: {method: 'GET', url: 'new/mock'}, responses: {'new-json-response': {}}
-                }));
+                }, {spaces: 2}));
         });
         describe('without a specified pattern', () => {
             beforeEach(() => {

--- a/src/core/convert.ts
+++ b/src/core/convert.ts
@@ -31,7 +31,7 @@ export class Converter {
                 delete mock.method;
             }
 
-            fs.outputJsonSync(destination, mock);
+            fs.outputJsonSync(destination, mock, {spaces: 2});
             console.log(`'${source}' -> '${destination}`);
         });
     }


### PR DESCRIPTION
Converted Mocks are formatted on 1 line. This PR fixes it and formats Mocks correctly.