### PR TITLE
Support file watching for patterns other than mocks

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,15 +34,19 @@ apimock.processor.process({
     patterns: { // optional
         mocks: '**/*Mock.json', // optional: default is '**/*.mock.json'
         presets: '**/*Preset.json', // optional: default is '**/*.preset.json'
-        mockWatches: '**/*.json' // optional: no default, set if watch files regex is different from mocks pattern
+    },
+    watches: { // optional
+        mocks: '**/*.json', // optional: no default, set if watch files regex is different from mocks pattern
+        presets: '**/*.json' // optional: no default, set if watch files regex is different from presets pattern
     },
     watch: true // optional: default is 'false'
 });
 ```
 
-There are 3 parameters here:
-- **src**: this is the directory that will be use to search for mocks and presets.
-- **patterns**: there are 3 regex patterns that can be overridden, mocks, presets and mockWatches. 
+There are 4 parameters here:
+- **src**: this is the directory that will be used to search for mocks and presets.
+- **patterns**: there are 2 regex patterns that can be overridden, mocks and presets. 
+- **watches**: set these if the patterns differ from the files to watch. Typically needed when using js instead of json.
 - **watch**: set to true will ensure that ng-apimock will watch for file changes.
 
 :::caution

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,8 @@ apimock.processor.process({
     src: 'mocks', // required
     patterns: { // optional
         mocks: '**/*Mock.json', // optional: default is '**/*.mock.json'
-        presets: '**/*Preset.json' // optional: default is '**/*.preset.json'
+        presets: '**/*Preset.json', // optional: default is '**/*.preset.json'
+        mockWatches: '**/*.json' // optional: no default
     },
     watch: true // optional: default is 'false'
 });
@@ -41,7 +42,7 @@ apimock.processor.process({
 
 There are 3 parameters here:
 - **src**: this is the directory that will be use to search for mocks and presets.
-- **patterns**: there are 2 regex patterns that can be overridden, mocks and presets. 
+- **patterns**: there are 3 regex patterns that can be overridden, mocks, presets and mockWatches. 
 - **watch**: set to true will ensure that ng-apimock will watch for file changes.
 
 :::caution

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,7 +34,7 @@ apimock.processor.process({
     patterns: { // optional
         mocks: '**/*Mock.json', // optional: default is '**/*.mock.json'
         presets: '**/*Preset.json', // optional: default is '**/*.preset.json'
-        mockWatches: '**/*.json' // optional: no default
+        mockWatches: '**/*.json' // optional: no default, set if watch files regex is different from mocks pattern
     },
     watch: true // optional: default is 'false'
 });
@@ -72,7 +72,7 @@ app.use(apimock.middleware);
 The default bodyParser library that is used has a body limit is `100kb`. In order to increase the limit you can set the limit like this:
 
 ```js
-app.use(bodyParser.json({limit: '10mb'});
+app.use(bodyParser.json({limit: '10mb'}));
 ```
 
 #### Middleware configuration

--- a/docs/mocks.md
+++ b/docs/mocks.md
@@ -1,4 +1,4 @@
-A mock in [@ng-apimock/core](https://github.com/ng-apimock/core) is represented in a json file that follows the request / response principle.
+A mock in [@ng-apimock/core](https://github.com/ng-apimock/core) is represented in a json/js file that follows the request / response principle.
 
 ## Writing a mock file
 Mocks in [@ng-apimock/core](https://github.com/ng-apimock/core) are written in json or javascript.
@@ -55,7 +55,7 @@ module.exports = {
 Writing a mock should always follow the [json schema](#json-schema).
 
 ### Advanced request matching
-When [@ng-apimock/core](https://github.com/ng-apimock/core) tries to match a request to a mock ,it will always look at the required fields of the request.
+When [@ng-apimock/core](https://github.com/ng-apimock/core) tries to match a request to a mock, it will always look at the required fields of the request.
 But when the request is configured with the header and body, it will also use that information to match.
 
 Looking at the following request configuration
@@ -83,7 +83,7 @@ Looking at the following request configuration
 }
 ```
 the request will only match when the 
-- Content-type header is of typ 'application/json'
+- Content-type header is of type 'application/json'
 - The body contains an item that matches the regex
 
 ### Chaining responses
@@ -117,11 +117,10 @@ Looking at the following response configuration
                 }],
                 "times": 3 // optional
             }
-          }
-        },
-        "internal_server_error": {
-            "status": 500
         }
+    },
+    "internal_server_error": {
+        "status": 500
     }
 }
 ```

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -1,10 +1,10 @@
-A preset in [@ng-apimock/core](https://github.com/ng-apimock/core) is represented in a json file.
+A preset in [@ng-apimock/core](https://github.com/ng-apimock/core) is represented in a json/js file.
 It allows you to set the state of one or multiple mocks and set variables all at once.
 
-This can for instance be used to set all the mocks correctly for your happy or onhappy flow.
+This can for instance be used to set all the mocks correctly for your happy or unhappy flow.
 
 ## Writing a preset file
-Presets in [@ng-apimock/core](https://github.com/ng-apimock/core) are written in json.
+Presets in [@ng-apimock/core](https://github.com/ng-apimock/core) are written in json or javascript.
 There is only one rule to follow when writing a preset file.
 1. It has a unique name
 

--- a/src/core/processor/mocks.processor.spec.ts
+++ b/src/core/processor/mocks.processor.spec.ts
@@ -194,7 +194,7 @@ describe('MocksProcessor', () => {
         describe('with mockWatches set', () => {
             beforeEach(() => {
                 globSyncFn.mockReturnValue([]);
-                processor.process({ src: 'src', patterns: { mocks: '**/*.mymock.json', mockWatches: '*/*' } });
+                processor.process({ src: 'src', patterns: { mocks: '**/*.mymock.json', mockWatches: '**/*' } });
             });
             it('processes each mockWatch and mock', () => {
                 expect(globSyncFn).toHaveBeenCalledWith(

--- a/src/core/processor/mocks.processor.spec.ts
+++ b/src/core/processor/mocks.processor.spec.ts
@@ -190,5 +190,24 @@ describe('MocksProcessor', () => {
                 );
             });
         });
+
+        describe('with mockWatches set', () => {
+            beforeEach(() => {
+                globSyncFn.mockReturnValue([]);
+                processor.process({ src: 'src', patterns: { mocks: '**/*.mymock.json', mockWatches: '*/*' } });
+            });
+            it('processes each mockWatch and mock', () => {
+                expect(globSyncFn).toHaveBeenCalledWith(
+                    '**/*', {
+                        cwd: 'src', root: '/', nodir: true
+                    }
+                );
+                expect(globSyncFn).toHaveBeenCalledWith(
+                    '**/*.mymock.json', {
+                        cwd: 'src', root: '/'
+                    }
+                );
+            });
+        });
     });
 });

--- a/src/core/processor/mocks.processor.spec.ts
+++ b/src/core/processor/mocks.processor.spec.ts
@@ -191,12 +191,12 @@ describe('MocksProcessor', () => {
             });
         });
 
-        describe('with mockWatches set', () => {
+        describe('with mock watches set', () => {
             beforeEach(() => {
                 globSyncFn.mockReturnValue([]);
-                processor.process({ src: 'src', patterns: { mocks: '**/*.mymock.json', mockWatches: '**/*' } });
+                processor.process({ src: 'src', patterns: { mocks: '**/*.mymock.json' }, watches: { mocks: '**/*' } });
             });
-            it('processes each mockWatch and mock', () => {
+            it('processes each mock watch and mock pattern', () => {
                 expect(globSyncFn).toHaveBeenCalledWith(
                     '**/*', {
                         cwd: 'src', root: '/', nodir: true

--- a/src/core/processor/mocks.processor.ts
+++ b/src/core/processor/mocks.processor.ts
@@ -32,7 +32,7 @@ export class MocksProcessor {
      */
     process(options: ProcessingOptions): void {
         let counter = 0;
-        const pattern = options.patterns.mocks;
+        const pattern = options.patterns.mockWatches || options.patterns.mocks;
 
         glob.sync(pattern, {
             cwd: options.src,

--- a/src/core/processor/mocks.processor.ts
+++ b/src/core/processor/mocks.processor.ts
@@ -31,9 +31,9 @@ export class MocksProcessor {
      * @param {ProcessingOptions} options The processing options.
      */
     process(options: ProcessingOptions): void {
-        if (options.patterns.mockWatches) {
-            // trigger deletion of files matching mockWatches pattern from cache
-            glob.sync(options.patterns.mockWatches, {
+        if (options.watches?.mocks) {
+            // trigger deletion of files matching mock watches pattern from cache
+            glob.sync(options.watches.mocks, {
                 cwd: options.src,
                 root: '/',
                 nodir: true // prevents error if pattern matches a dir
@@ -44,6 +44,7 @@ export class MocksProcessor {
 
         let counter = 0;
         const pattern = options.patterns.mocks;
+
         glob.sync(pattern, {
             cwd: options.src,
             root: '/'

--- a/src/core/processor/processing.options.ts
+++ b/src/core/processor/processing.options.ts
@@ -3,7 +3,10 @@ export interface ProcessingOptions {
     patterns?: {
         mocks?: string;
         presets?: string;
-        mockWatches?: string;
+    };
+    watches?: {
+        mocks?: string;
+        presets?: string;
     };
     watch?: boolean;
 }

--- a/src/core/processor/processing.options.ts
+++ b/src/core/processor/processing.options.ts
@@ -3,6 +3,7 @@ export interface ProcessingOptions {
     patterns?: {
         mocks?: string;
         presets?: string;
+        mockWatches?: string;
     };
     watch?: boolean;
 }

--- a/src/core/processor/processor.spec.ts
+++ b/src/core/processor/processor.spec.ts
@@ -116,17 +116,45 @@ describe('MocksProcessor', () => {
             });
         });
 
-        describe('watch - with mockWatches set', () => {
+        describe('watch - with mock watches set', () => {
             beforeEach(() => {
                 processor.process({
                     src: 'src',
-                    patterns: { mocks: 'mocks-pattern', presets: 'presets-pattern', mockWatches: 'mock-watches' },
+                    patterns: { mocks: 'mocks-pattern', presets: 'presets-pattern' },
+                    watches: { mocks: 'mock-watches' },
                     watch: true
                 });
             });
 
-            it('watches for mockWatches changes when set', async () => {
+            it('watches for mock watches changes when set', async () => {
                 expect(chokidarWatchFn).toHaveBeenCalledWith('src/mock-watches', {
+                    ignoreInitial: true, usePolling: true, interval: 2000
+                });
+
+                expect(fsWatcher.on).toHaveBeenCalledWith('all', expect.anything());
+                expect(mocksProcessor.process).toHaveBeenCalledTimes(1);
+
+                const onAllCall = fsWatcher.on.mock.calls[0];
+
+                expect(onAllCall[0]).toBe('all');
+                await onAllCall[1](); // call the callback function.
+
+                expect(mocksProcessor.process).toHaveBeenCalledTimes(2);
+            });
+        });
+
+        describe('watch - with preset watches set', () => {
+            beforeEach(() => {
+                processor.process({
+                    src: 'src',
+                    patterns: { mocks: 'mocks-pattern', presets: 'presets-pattern' },
+                    watches: { presets: 'presets-watches' },
+                    watch: true
+                });
+            });
+
+            it('watches for preset watches changes when set', async () => {
+                expect(chokidarWatchFn).toHaveBeenCalledWith('src/presets-watches', {
                     ignoreInitial: true, usePolling: true, interval: 2000
                 });
 

--- a/src/core/processor/processor.spec.ts
+++ b/src/core/processor/processor.spec.ts
@@ -115,5 +115,31 @@ describe('MocksProcessor', () => {
                 expect(presetsProcessor.process).toHaveBeenCalledTimes(2);
             });
         });
+
+        describe('watch - with mockWatches set', () => {
+            beforeEach(() => {
+                processor.process({
+                    src: 'src',
+                    patterns: { mocks: 'mocks-pattern', presets: 'presets-pattern', mockWatches: 'mock-watches' },
+                    watch: true
+                });
+            });
+
+            it('watches for mockWatches changes when set', async () => {
+                expect(chokidarWatchFn).toHaveBeenCalledWith('src/mock-watches', {
+                    ignoreInitial: true, usePolling: true, interval: 2000
+                });
+
+                expect(fsWatcher.on).toHaveBeenCalledWith('all', expect.anything());
+                expect(mocksProcessor.process).toHaveBeenCalledTimes(1);
+
+                const onAllCall = fsWatcher.on.mock.calls[0];
+
+                expect(onAllCall[0]).toBe('all');
+                await onAllCall[1](); // call the callback function.
+
+                expect(mocksProcessor.process).toHaveBeenCalledTimes(2);
+            });
+        });
     });
 });

--- a/src/core/processor/processor.ts
+++ b/src/core/processor/processor.ts
@@ -30,19 +30,11 @@ export class Processor {
         this.presetsProcessor.process(opts);
 
         if (opts.watch) {
-            if (opts.patterns.mockWatches) {
-                chokidar.watch(`${opts.src}/${opts.patterns.mockWatches}`, {
-                    ignoreInitial: true,
-                    usePolling: true,
-                    interval: 2000
-                }).on('all', () => this.mocksProcessor.process(opts));
-            } else {
-                chokidar.watch(`${opts.src}/${opts.patterns.mocks}`, {
-                    ignoreInitial: true,
-                    usePolling: true,
-                    interval: 2000
-                }).on('all', () => this.mocksProcessor.process(opts));
-            }
+            chokidar.watch(`${opts.src}/${opts.patterns.mockWatches || opts.patterns.mocks}`, {
+                ignoreInitial: true,
+                usePolling: true,
+                interval: 2000
+            }).on('all', () => this.mocksProcessor.process(opts));
             chokidar.watch(`${opts.src}/${opts.patterns.presets}`, {
                 ignoreInitial: true,
                 usePolling: true,

--- a/src/core/processor/processor.ts
+++ b/src/core/processor/processor.ts
@@ -36,14 +36,13 @@ export class Processor {
                     usePolling: true,
                     interval: 2000
                 }).on('all', () => this.mocksProcessor.process(opts));
+            } else {
+                chokidar.watch(`${opts.src}/${opts.patterns.mocks}`, {
+                    ignoreInitial: true,
+                    usePolling: true,
+                    interval: 2000
+                }).on('all', () => this.mocksProcessor.process(opts));
             }
-
-            chokidar.watch(`${opts.src}/${opts.patterns.mocks}`, {
-                ignoreInitial: true,
-                usePolling: true,
-                interval: 2000
-            }).on('all', () => this.mocksProcessor.process(opts));
-
             chokidar.watch(`${opts.src}/${opts.patterns.presets}`, {
                 ignoreInitial: true,
                 usePolling: true,

--- a/src/core/processor/processor.ts
+++ b/src/core/processor/processor.ts
@@ -30,6 +30,14 @@ export class Processor {
         this.presetsProcessor.process(opts);
 
         if (opts.watch) {
+            if (opts.patterns.mockWatches) {
+                chokidar.watch(`${opts.src}/${opts.patterns.mockWatches}`, {
+                    ignoreInitial: true,
+                    usePolling: true,
+                    interval: 2000
+                }).on('all', () => this.mocksProcessor.process(opts));
+            }
+
             chokidar.watch(`${opts.src}/${opts.patterns.mocks}`, {
                 ignoreInitial: true,
                 usePolling: true,

--- a/src/core/processor/processor.ts
+++ b/src/core/processor/processor.ts
@@ -30,12 +30,12 @@ export class Processor {
         this.presetsProcessor.process(opts);
 
         if (opts.watch) {
-            chokidar.watch(`${opts.src}/${opts.patterns.mockWatches || opts.patterns.mocks}`, {
+            chokidar.watch(`${opts.src}/${opts.watches?.mocks || opts.patterns.mocks}`, {
                 ignoreInitial: true,
                 usePolling: true,
                 interval: 2000
             }).on('all', () => this.mocksProcessor.process(opts));
-            chokidar.watch(`${opts.src}/${opts.patterns.presets}`, {
+            chokidar.watch(`${opts.src}/${opts.watches?.presets || opts.patterns.presets}`, {
                 ignoreInitial: true,
                 usePolling: true,
                 interval: 2000


### PR DESCRIPTION
Adding a variable called mockWatches to define a pattern for files to watch if they differ from mocks pattern. It is backwards compatible. 