### PR TITLE
Added errormessage in case of preset referencing an unknown mock

### DIFF
--- a/src/core/middleware/handlers/api/select-preset.handler.spec.ts
+++ b/src/core/middleware/handlers/api/select-preset.handler.spec.ts
@@ -77,6 +77,11 @@ describe('SelectPresetHandler', () => {
                     another: { scenario: 'no-match' }
                 },
                 variables: { today: 'some date' }
+            }, {
+                name: 'unknown-mock',
+                mocks: {
+                    invalid: {  scenario: 'success', delay: 2000, echo: true }
+                }
             }];
             matchingState = {
                 mocks: JSON.parse(JSON.stringify({
@@ -225,6 +230,27 @@ describe('SelectPresetHandler', () => {
             });
         });
 
+        describe('unknown mock in preset', () => {
+            beforeEach(() => {
+                const body = { name: 'unknown-mock' };
+                handler.handle(request as any, response as any, nextFn, {
+                    id: 'apimockId',
+                    body
+                });
+            });
+
+            afterEach(() => {
+                jest.clearAllMocks();
+            });
+
+            it('throws an error when an unknown mock is in the preset', () => {
+                expect(debugFn).toHaveBeenCalledTimes(1);
+                expect(debugFn).toHaveBeenCalledWith(expect.stringContaining('Preset [\'unknown-mock\'] references unknown mock with name [\'invalid\']'));
+                expect(response.writeHead).toHaveBeenCalledWith(HttpStatusCode.INTERNAL_SERVER_ERROR, HttpHeaders.CONTENT_TYPE_APPLICATION_JSON);
+                expect(response.end).toHaveBeenCalledWith(JSON.stringify({ message: 'Preset [\'unknown-mock\'] references unknown mock with name [\'invalid\']' }));
+            }); 
+        });
+
         describe('no matching preset', () => {
             beforeEach(() => {
                 const body = { name: 'no-match' };
@@ -242,6 +268,8 @@ describe('SelectPresetHandler', () => {
             });
         });
     });
+
+    
 
     describe('isApplicable', () => {
         let request: http.IncomingMessage;

--- a/src/core/middleware/handlers/api/select-preset.handler.spec.ts
+++ b/src/core/middleware/handlers/api/select-preset.handler.spec.ts
@@ -80,7 +80,7 @@ describe('SelectPresetHandler', () => {
             }, {
                 name: 'unknown-mock',
                 mocks: {
-                    invalid: {  scenario: 'success', delay: 2000, echo: true }
+                    invalid: { scenario: 'success', delay: 2000, echo: true }
                 }
             }];
             matchingState = {
@@ -248,7 +248,7 @@ describe('SelectPresetHandler', () => {
                 expect(debugFn).toHaveBeenCalledWith(expect.stringContaining('Preset [\'unknown-mock\'] references unknown mock with name [\'invalid\']'));
                 expect(response.writeHead).toHaveBeenCalledWith(HttpStatusCode.INTERNAL_SERVER_ERROR, HttpHeaders.CONTENT_TYPE_APPLICATION_JSON);
                 expect(response.end).toHaveBeenCalledWith(JSON.stringify({ message: 'Preset [\'unknown-mock\'] references unknown mock with name [\'invalid\']' }));
-            }); 
+            });
         });
 
         describe('no matching preset', () => {
@@ -268,8 +268,6 @@ describe('SelectPresetHandler', () => {
             });
         });
     });
-
-    
 
     describe('isApplicable', () => {
         let request: http.IncomingMessage;

--- a/src/core/middleware/handlers/api/select-preset.handler.ts
+++ b/src/core/middleware/handlers/api/select-preset.handler.ts
@@ -79,6 +79,9 @@ export class SelectPresetHandler implements ApplicableHandler {
             Object.keys(preset.mocks).forEach((mock) => {
                 const mockState: MockState = preset.mocks[mock];
                 const matchingMock: Mock = this.state.mocks.find((_mock) => _mock.name === mock);
+                if (!matchingMock) {
+                    throw new Error(`Preset ['${preset.name}'] references unknown mock with name ['${mock}']`);
+                }                
                 const scenarioExists = Object.keys(matchingMock.responses)
                     .find((scenario) => scenario === mockState.scenario) !== undefined;
 

--- a/src/core/middleware/handlers/api/select-preset.handler.ts
+++ b/src/core/middleware/handlers/api/select-preset.handler.ts
@@ -81,7 +81,7 @@ export class SelectPresetHandler implements ApplicableHandler {
                 const matchingMock: Mock = this.state.mocks.find((_mock) => _mock.name === mock);
                 if (!matchingMock) {
                     throw new Error(`Preset ['${preset.name}'] references unknown mock with name ['${mock}']`);
-                }                
+                }
                 const scenarioExists = Object.keys(matchingMock.responses)
                     .find((scenario) => scenario === mockState.scenario) !== undefined;
 


### PR DESCRIPTION
Hi Midas,

we've just started using ng-apimock. Ng-apimock suits our needs.
A couple of times we've ran into the situation that our tests broke down. After some hours we were able to track down the origin. For this situation i've added an error-message and a unit-test.

We would be very happy if you are able to complete this Pull Request and publish an updated version.

thanks in advance,
Sander