### PR TITLE
Add urlencoded and text middleware support

### DIFF
--- a/docs/mocks.md
+++ b/docs/mocks.md
@@ -58,6 +58,7 @@ Writing a mock should always follow the [json schema](#json-schema).
 When [@ng-apimock/core](https://github.com/ng-apimock/core) tries to match a request to a mock, it will always look at the required fields of the request.
 But when the request is configured with the header and body, it will also use that information to match.
 
+#### JSON content
 Looking at the following request configuration
 ```json
 {
@@ -85,6 +86,81 @@ Looking at the following request configuration
 the request will only match when the 
 - Content-type header is of type 'application/json'
 - The body contains an item that matches the regex
+
+#### URL encoded content
+URL encoded content is a bit different. The body will be parsed and the resulting object will be used 
+to match the request. For example if the message payload looks like this:
+
+```text
+foo=bar&baz=qux&page=2
+```
+the body will be parsed to:
+```json
+{
+    "foo": "bar",
+    "baz": "qux",
+    "page": "2"
+}
+```
+
+So, looking at the following request configuration
+```json
+{
+    "name": "another mock",
+    "request": {
+        "url": "^/some/encoded-thing$",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        "body": {
+            "foo": "bar",
+            "baz": "q(ux)?",
+            "page": "[0-9]+"
+        }
+    },
+    "responses": {
+        "ok": {
+            "default": true
+        },
+        "internal_server_error": {
+            "status": 500
+        }
+    }
+}
+```
+the request will only match when the 
+- Content-type header is of type 'application/x-www-form-urlencoded'
+- Each item in the decoded message matches the regex values in the body
+
+#### Text content
+Text content is more straightforward. The body will be matched against the regex value.
+
+looking at the following request configuration
+```json
+{
+    "name": "third mock",
+    "request": {
+        "url": "^/some/text-thing$",
+        "method": "POST",
+        "headers": {
+            "Content-Type": "text/*"
+        },
+        "body": "^[a-zA-Z]{3,10}$"
+    },
+    "responses": {
+        "ok": {
+            "default": true
+        },
+        "internal_server_error": {
+            "status": 500
+        }
+    }
+}
+```
+the request will only match when the 
+- Content-type header starts with 'text/'
+- The body matches the regex value
 
 ### Chaining responses
 [@ng-apimock/core](https://github.com/ng-apimock/core) can also chain mock responses using then clauses.

--- a/src/core/ioc-container.ts
+++ b/src/core/ioc-container.ts
@@ -72,6 +72,8 @@ container.bind<MocksProcessor>('MocksProcessor').to(MocksProcessor);
 container.bind<PresetsProcessor>('PresetsProcessor').to(PresetsProcessor);
 container.bind<Processor>('Processor').to(Processor);
 container.bind<NextHandleFunction>('JsonBodyParser').toConstantValue(bodyParser.json());
+container.bind<NextHandleFunction>('UrlEncodedBodyParser').toConstantValue(bodyParser.urlencoded({ extended: true }));
+container.bind<NextHandleFunction>('TextBodyParser').toConstantValue(bodyParser.text());
 container.bind<Middleware>('Middleware').to(Middleware);
 
 container.bind<CreateMockHandler>('CreateMockHandler').to(CreateMockHandler);

--- a/src/core/middleware/middleware.spec.ts
+++ b/src/core/middleware/middleware.spec.ts
@@ -36,6 +36,8 @@ import { Middleware } from './middleware';
 describe('Middleware', () => {
     let container: Container;
     let jsonBodyParser: jest.Mock;
+    let urlEncodedBodyParser: jest.Mock;
+    let textBodyParser: jest.Mock;
     let state: jest.Mocked<State>;
 
     let addMockToPresetHandler: AddMockScenarioToPresetHandler;
@@ -66,6 +68,8 @@ describe('Middleware', () => {
     beforeEach(() => {
         container = new Container();
         jsonBodyParser = jest.fn();
+        urlEncodedBodyParser = jest.fn();
+        textBodyParser = jest.fn();
         state = createSpyObj(State);
 
         addMockToPresetHandler = createSpyObj(AddMockScenarioToPresetHandler);
@@ -93,6 +97,8 @@ describe('Middleware', () => {
 
         container.bind<Configuration>('Configuration').toConstantValue(DefaultConfiguration);
         container.bind('JsonBodyParser').toConstantValue(jsonBodyParser);
+        container.bind('UrlEncodedBodyParser').toConstantValue(urlEncodedBodyParser);
+        container.bind('TextBodyParser').toConstantValue(textBodyParser);
         container.bind('State').toConstantValue(state);
 
         container.bind('AddMockScenarioToPresetHandler').toConstantValue(addMockToPresetHandler);
@@ -160,6 +166,8 @@ describe('Middleware', () => {
                 middleware.middleware(request, response, nextFn);
 
                 jsonBodyParser.mock.calls[0][2]();
+                urlEncodedBodyParser.mock.calls[0][2]();
+                textBodyParser.mock.calls[0][2]();
             });
 
             it('gets the apimock id', () => expect(getApimockIdFn).toHaveBeenCalled());
@@ -197,6 +205,8 @@ describe('Middleware', () => {
                     middleware.middleware(request, response, nextFn);
 
                     jsonBodyParser.mock.calls[0][2]();
+                    urlEncodedBodyParser.mock.calls[0][2]();
+                    textBodyParser.mock.calls[0][2]();
                 });
 
                 it('gets the apimock id', () => expect(getApimockIdFn).toHaveBeenCalled());
@@ -250,6 +260,8 @@ describe('Middleware', () => {
                         middleware.middleware(request, response, nextFn);
 
                         jsonBodyParser.mock.calls[0][2]();
+                        urlEncodedBodyParser.mock.calls[0][2]();
+                        textBodyParser.mock.calls[0][2]();
                     });
 
                     it('does not call the record response handler', () => expect(recordResponseHandler.handle).not.toHaveBeenCalled());
@@ -261,6 +273,8 @@ describe('Middleware', () => {
                         middleware.middleware(request, response, nextFn);
 
                         jsonBodyParser.mock.calls[0][2]();
+                        urlEncodedBodyParser.mock.calls[0][2]();
+                        textBodyParser.mock.calls[0][2]();
                     });
 
                     it('calls the record response handler',
@@ -302,6 +316,8 @@ describe('Middleware', () => {
                     middleware.middleware(request, response, nextFn);
 
                     jsonBodyParser.mock.calls[0][2]();
+                    urlEncodedBodyParser.mock.calls[0][2]();
+                    textBodyParser.mock.calls[0][2]();
                 });
 
                 it('calls the mock request handler', () => expect(mockRequestHandler.handle).toHaveBeenCalledWith(request,
@@ -330,6 +346,8 @@ describe('Middleware', () => {
                 middleware.middleware(request, response, nextFn);
 
                 jsonBodyParser.mock.calls[0][2]();
+                urlEncodedBodyParser.mock.calls[0][2]();
+                textBodyParser.mock.calls[0][2]();
             });
 
             it('calls next', () => expect(nextFn).toHaveBeenCalled());

--- a/src/core/mock/mock.request.ts
+++ b/src/core/mock/mock.request.ts
@@ -5,7 +5,7 @@ export interface MockRequest {
     // the http method (GET, POST, PUT, DELETE)
     method: string;
     // body
-    body?: { [key: string]: any };
+    body?: { [key: string]: any } | string;
     // body
     headers?: { [key: string]: string };
 }

--- a/src/core/state/state.spec.ts
+++ b/src/core/state/state.spec.ts
@@ -101,15 +101,6 @@ describe('State', () => {
                     body: { nested: { number: '\\d+', identifier: '^[a-zA-Z]{4}$', tuple: ['\\d+', '[\'true\'|\'false\']'] } }
                 },
                 responses: { three: {}, four: {} }
-            }, {
-                name: 'similar-advanced-nested',
-                request: {
-                    url: 'some/api',
-                    method: 'POST',
-                    headers: { 'Content-Type': '.*/json', 'Cache-Control': 'no-cache' },
-                    body: { nested: { number: '\\d+', identifier: '^[a-zA-Z]{4}$', tuple: ['\\d+', '[\'true\'|\'false\']'] } }
-                },
-                responses: { three: {}, four: {} }
             }]);
         });
         describe('url does not match', () => {

--- a/src/core/state/state.spec.ts
+++ b/src/core/state/state.spec.ts
@@ -75,12 +75,30 @@ describe('State', () => {
                 },
                 responses: { three: {}, four: {} }
             }, {
+                name: 'advanced-flat',
+                request: {
+                    url: 'some/api',
+                    method: 'POST',
+                    headers: { 'Content-Type': '.*/x-www-form-urlencoded', 'Cache-Control': 'no-cache' },
+                    body: '^[a-zA-Z]{4}$'
+                },
+                responses: { three: {}, four: {} }
+            }, {
                 name: 'advanced-nested',
                 request: {
                     url: 'some/api',
                     method: 'POST',
                     headers: { 'Content-Type': '.*/json', 'Cache-Control': 'no-cache' },
                     body: { nested: { number: '\\d+', identifier: '^[a-zA-Z]{4}$' } }
+                },
+                responses: { three: {}, four: {} }
+            }, {
+                name: 'similar-advanced-nested',
+                request: {
+                    url: 'some/api',
+                    method: 'POST',
+                    headers: { 'Content-Type': '.*/json', 'Cache-Control': 'no-cache' },
+                    body: { nested: { number: '\\d+', identifier: '^[a-zA-Z]{4}$', tuple: ['\\d+', '[\'true\'|\'false\']'] } }
                 },
                 responses: { three: {}, four: {} }
             }, {
@@ -148,6 +166,20 @@ describe('State', () => {
                         method: 'POST',
                         headers: { 'Content-Type': '.*/json', 'Cache-Control': 'no-cache' },
                         body: { number: '\\d+', identifier: '^[a-zA-Z]{4}$' }
+                    },
+                    responses: { three: {}, four: {} }
+                });
+                // match advanced mock - url, method, headers, body
+                expect(state.getMatchingMock('some/api', 'POST', {
+                    'content-type': 'application/x-www-form-urlencoded',
+                    'cache-control': 'no-cache'
+                }, 'abcd')).toEqual({
+                    name: 'advanced-flat',
+                    request: {
+                        url: 'some/api',
+                        method: 'POST',
+                        headers: { 'Content-Type': '.*/x-www-form-urlencoded', 'Cache-Control': 'no-cache' },
+                        body: '^[a-zA-Z]{4}$'
                     },
                     responses: { three: {}, four: {} }
                 });

--- a/src/core/state/state.ts
+++ b/src/core/state/state.ts
@@ -122,15 +122,22 @@ export class State {
      * @return {boolean} indicator The indicator.
      */
     matchesBody(bodyMatcher: any, body: any): boolean {
-        return Object.keys(bodyMatcher).length === Object.keys(body).length
-            && Object.keys(bodyMatcher).every((key) => {
-                if (typeof bodyMatcher[key] === 'object') {
-                    return body[key] !== undefined ? this.matchesBody(bodyMatcher[key], body[key]) : false;
-                }
-                const defined = body[key] !== undefined;
-                const matched = new RegExp(bodyMatcher[key]).exec(body[key]) !== null;
-                return defined && matched;
-            });
+        let result = false;
+
+        if (typeof body === 'string') {
+            result = new RegExp(bodyMatcher).exec(body) !== null;
+        } else if (typeof body === 'object' && body !== null) {
+            result = Object.keys(bodyMatcher).length === Object.keys(body).length
+                && Object.keys(bodyMatcher).every((key) => {
+                    if (typeof bodyMatcher[key] === 'object') {
+                        return body[key] !== undefined ? this.matchesBody(bodyMatcher[key], body[key]) : false;
+                    }
+                    const defined = body[key] !== undefined;
+                    const matched = new RegExp(bodyMatcher[key]).exec(body[key]) !== null;
+                    return defined && matched;
+                });
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
My previous PR was not enough to get all my use cases to work. In this PR I update the middleware to handle json, urlencoded, and text content types. I also updated the documentation with examples.