### PR TITLE
build: fix TypeScript declaration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ To start up the script just type:
 node serve.js
 ```
 
+### Minimal setup example (serve.ts)
+This is a minimal setup example in TypeScript of how you can manually use @ng-apimock/core
+```ts
+import * as apimock from '@ng-apimock/core';
+import express, { Application } from 'express';
+const app: Application = express();
+app.set('port', 9999);
+
+apimock.processor.process({
+    src: 'mocks'
+});
+
+app.use(apimock.middleware);
+
+app.listen(app.get('port'), () => {
+    console.log('@ng-apimock/core running on port', app.get('port'));
+});
+```
+
+
 ### Endpoints
 There are a few endpoints available when you startup `@ng-apimock/core`:
 - `/ngapimock/info` - responsible for providing information of the running instance

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "email": "mischa@dasberg.nl"
     },
     "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "scripts": {
         "precompile": "rimraf dist",
         "compile": "tsc",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -45,4 +45,4 @@ class NgApimock {
     }
 }
 
-module.exports = new NgApimock();
+export = new NgApimock();


### PR DESCRIPTION
The current package delivers the following `index.d.ts`:

```ts 
export {};
```

With these updates, the new `index.d.ts` is:

```ts
/// <reference types="node" />
import * as http from 'http';
import { Configuration } from './configuration';
import { Converter } from './convert';
import { Processor } from './processor/processor';
declare class NgApimock {
    configure(configuration: Configuration): void;
    get processor(): Processor;
    middleware(request: http.IncomingMessage, response: http.ServerResponse, next: Function): void;
    get converter(): Converter;
}
declare const _default: NgApimock;
export = _default;
```

Which allowed me to use it in a `serve.ts`:

```ts
import * as apimock from '@ng-apimock/core';
import express, { Application } from 'express';
const app: Application = express();
app.set('port', 9999);

apimock.processor.process({
    src: 'mocks'
});

app.use(apimock.middleware);

app.listen(app.get('port'), () => {
    console.log('@ng-apimock/core running on port', app.get('port'));
});
```